### PR TITLE
Update composer check to be more granular

### DIFF
--- a/travis/composer_check.py
+++ b/travis/composer_check.py
@@ -15,11 +15,10 @@ def main(orig_file, new_file):
     new_content = read_json(new_file)
 
     for key in ['require', 'require-dev', 'extra']:
-        left = value_or_else(orig_content, key)
-        right = value_or_else(new_content, key)
+        left = orig_content.get(key, {})
+        right = new_content.get(key, {})
 
-        (added, removed, modified) = dict_compare(left, right)
-        if len(added) > 0 or len(removed) > 0 or len(modified) > 0:
+        if left != right:
             exit(1)
 
 
@@ -31,40 +30,6 @@ def read_json(path):
     """
     with open(path, 'r') as fh:
         return json.load(fh)
-
-
-def value_or_else(data, key, default=None):
-    """
-    A helper method that retrieves the value from `data` for `key` if it exists,
-    else it returns `default`.
-
-    :param dict data:
-    :param string key:
-    :param default:
-    :return:
-    """
-    if default is None:
-        default = {}
-    return data[key] if key in data else default
-
-
-def dict_compare(left, right):
-    """
-    Compares two dictionaries, left to right. It returns a 3-tuple that contains
-    the entries that were added, removed, and modified.
-
-    :param dict left:
-    :param dict right:
-    :return: (added, removed, modified)
-    """
-    lkeys = set(left.keys())
-    rkeys = set(right.keys())
-    intersect_keys = lkeys.intersection(rkeys)
-    added = lkeys - rkeys
-    removed = rkeys - lkeys
-    modified = {o: (left[o], right[o]) for o in intersect_keys if
-                left[o] != right[o]}
-    return added, removed, modified
 
 
 if __name__ == '__main__':

--- a/travis/composer_check.py
+++ b/travis/composer_check.py
@@ -1,10 +1,5 @@
 import argparse
-import os
 import json
-
-# the scripts current working directory. Used in defining default values for
-# this script
-cwd = os.getcwd()
 
 
 def main(orig_file, new_file):
@@ -77,10 +72,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Determines whether or not composer.json changes require an associated composer.lock change.")
     parser.add_argument('original_file', type=str, nargs="?",
-                        default=os.path.join(cwd, "composer.orig.json"),
+                        default="composer.orig.json",
                         help="The original version of composer.json")
     parser.add_argument('new_file', type=str, nargs="?",
-                        default=os.path.join(cwd, 'composer.json'))
+                        default="composer.json")
 
     args = parser.parse_args()
 

--- a/travis/composer_check.py
+++ b/travis/composer_check.py
@@ -48,6 +48,8 @@ def value_or_else(data, key, default=None):
     :param default:
     :return:
     """
+    if default is None:
+        default = {}
     return data[key] if key in data else default
 
 

--- a/travis/composer_check.py
+++ b/travis/composer_check.py
@@ -35,7 +35,7 @@ def read_json(path):
     :return:
     """
     with open(path, 'r') as fh:
-        return json.loads(fh.read())
+        return json.load(fh)
 
 
 def value_or_else(data, key, default=None):

--- a/travis/composer_check.py
+++ b/travis/composer_check.py
@@ -1,0 +1,85 @@
+import argparse
+import os
+import json
+
+# the scripts current working directory. Used in defining default values for
+# this script
+cwd = os.getcwd()
+
+
+def main(orig_file, new_file):
+    """
+    Reads / parses content from the `original_file` and the `new_file`. For each
+    section that we care about ( 'require', 'require-dev', 'extra ), determine whether
+    anything has been added, removed or modified in `new_file`. If there have
+    been changes then we exit w/ a non-zero exit code to indicate that additional
+    validation may be required. If there are no changes detected then we exit w/
+    a zero exit code.
+    """
+    orig_content = read_json(orig_file)
+    new_content = read_json(new_file)
+
+    for key in ['require', 'require-dev', 'extra']:
+        left = value_or_else(orig_content, key)
+        right = value_or_else(new_content, key)
+
+        (added, removed, modified) = dict_compare(left, right)
+        if len(added) > 0 or len(removed) > 0 or len(modified) > 0:
+            exit(1)
+
+
+def read_json(path):
+    """
+    Helper method that opens / parses a json file, returning its contents.
+    :param str path:
+    :return:
+    """
+    with open(path, 'r') as fh:
+        return json.loads(fh.read())
+
+
+def value_or_else(data, key, default=None):
+    """
+    A helper method that retrieves the value from `data` for `key` if it exists,
+    else it returns `default`.
+
+    :param dict data:
+    :param string key:
+    :param default:
+    :return:
+    """
+    return data[key] if key in data else default
+
+
+def dict_compare(left, right):
+    """
+    Compares two dictionaries, left to right. It returns a 3-tuple that contains
+    the entries that were added, removed, and modified.
+
+    :param dict left:
+    :param dict right:
+    :return: (added, removed, modified)
+    """
+    lkeys = set(left.keys())
+    rkeys = set(right.keys())
+    intersect_keys = lkeys.intersection(rkeys)
+    added = lkeys - rkeys
+    removed = rkeys - lkeys
+    modified = {o: (left[o], right[o]) for o in intersect_keys if
+                left[o] != right[o]}
+    return added, removed, modified
+
+
+if __name__ == '__main__':
+    # Setup the arg parser for this script
+    parser = argparse.ArgumentParser(
+        description="Determines whether or not composer.json changes require an associated composer.lock change.")
+    parser.add_argument('original_file', type=str, nargs="?",
+                        default=os.path.join(cwd, "composer.orig.json"),
+                        help="The original version of composer.json")
+    parser.add_argument('new_file', type=str, nargs="?",
+                        default=os.path.join(cwd, 'composer.json'))
+
+    args = parser.parse_args()
+
+    main(args.original_file, args.new_file)


### PR DESCRIPTION
Currently if any portion of `composer.json` is modified then `composer.lock`
must be modified or the process fails. Unfortunately, there are some times
when we would legitimately expect there to be no change in `composer.lock` when
`composer.json` is updated ( say, for instance, new entries are added to the
`classmap` section ).

It turns out that there are only a few areas of `composer.json` that we should
be inspecting to determine whether or not `composer.lock` should also be
updated.

This commit adds a new script `composer_check.py` that, when run, will compare
these sections for the current and original `composer.json`. If a difference is
found then its exit code will not be 0, else it will be 0.

`build.sh` has been updated to run this script and take the appropriate action
if there are changes detected.