### PR TITLE
Update for more renames and line length

### DIFF
--- a/style/configs/phpcs.xml
+++ b/style/configs/phpcs.xml
@@ -23,7 +23,7 @@
   </rule>
   <rule ref="Generic.Files.LineLength">
       <properties>
-          <property name="lineLimit" value="512"/>
+          <property name="lineLimit" value="2000"/>
           <property name="absoluteLineLimit" value="0"/>
       </properties>
   </rule>

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -137,7 +137,7 @@ while IFS= read -r -d $'\0' file; do
     if [[ ! $file =~ ^tests/artifacts ]]; then
         files_changed+=("$file")
     fi
-done < <(git diff --name-only --diff-filter=dar -z "$TRAVIS_COMMIT_RANGE")
+done < <(git -c diff.renameLimit=6000 diff --name-only --diff-filter=dar -z "$TRAVIS_COMMIT_RANGE")
 
 # Separate the changed files by language.
 php_files_changed=()
@@ -172,7 +172,7 @@ while IFS= read -r -d $'\0' file; do
     elif [[ "$file" == *.json ]]; then
         json_files_added+=("$file")
     fi
-done < <(git diff --name-only --diff-filter=AR -z "$TRAVIS_COMMIT_RANGE")
+done < <(git -c diff.renameLimit=6000 diff --name-only --diff-filter=AR -z "$TRAVIS_COMMIT_RANGE")
 
 # Find tracked files that were added (staged) or modified but not staged
 


### PR DESCRIPTION
allow line length of 2000 char (this is specifically for some of the shredder tests)
increase the diff rename limit to 6000