### PR TITLE
force composer to stay at version 1

### DIFF
--- a/travis/install.sh
+++ b/travis/install.sh
@@ -38,7 +38,7 @@ function install_dependencies() {
         # If Composer has not been initialized yet, do so.
         if ! $composer_initialized; then
             echo "Updating Composer..."
-            composer self-update --stable
+            composer self-update --stable --1
             composer_initialized=true
         fi
 


### PR DESCRIPTION
Composer is going to be updating to v2 soon and we dont want that as it is going to have higher version requirements than we want

https://github.com/composer/composer/issues/8753#issuecomment-611523491