### PR TITLE
Allow literal placeholder syntax in regular strings

### DIFF
--- a/style/configs/.eslintrc.json
+++ b/style/configs/.eslintrc.json
@@ -107,6 +107,7 @@
         "props": false
       }
     ],
-    "yoda": "off"
+    "yoda": "off",
+    "no-template-curly-in-string": "off"
   }
 }


### PR DESCRIPTION
Since we're using JavaScript to generate JSON, and that JSON may include a template format that uses the same syntax as ES6 template literals, I think we should consider allowing this syntax in regular strings.

See ubccr/xdmod-supremm#255 for an example.