### PR TITLE
Ignore Jekyll front matter when validating JSON files.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -270,7 +270,14 @@ for file in "${js_files_changed[@]}" "${js_files_added[@]}"; do
     fi
 done
 for file in "${json_files_changed[@]}" "${json_files_added[@]}"; do
-    jsonlint --quiet "$file"
+    jsonlint="jsonlint --quiet"
+    # If the file is among the files used to generate the Jekyll static site,
+    # strip out any front matter before validating it.
+    if [[ "$file" =~ ^docs/* ]]; then
+        sed '1 { /^---/ { :a N; /\n---/! ba; d } }' $file | $jsonlint
+    else
+        $jsonlint "$file"
+    fi
     if [ $? != 0 ]; then
         syntax_exit_value=2
     fi


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR makes it so that JSON files in the `docs` directory will have any Jekyll front matter ignored when they are validated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/ubccr/xdmod/pull/1784 adds Jekyll front matter to a JSON file in the static site, which caused it to fail the `jsonlint` validation.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In a Docker container running `tools-ext-01.ccr.xdmod.org/xdmod-10.5.0-x86_64:rockylinux8.5-0.3`:
1. Run the following commands:
    ```
    git clone {https://github.com/ubccr,}/xdmod
    git clone https://github.com/ubccr/xdmod-qa /xdmod-qa-old
    git clone https://github.com/aaronweeden/xdmod-qa -b ignore-jekyll-front-matter-for-json-files /xdmod-qa-new
    cd /xdmod
    export XDMOD_IS_CORE=true
    /xdmod-qa-old/scripts/install.sh
    ```
1. Confirm this fails the syntax tests:
    ```
    echo -e "---\nlayout: null\n---\n{}" > docs/foo.json
    git add docs/foo.json
    /xdmod-qa-old/scripts/build.sh --remote origin/xdmod11.0
    ```
1. Confirm this passes the syntax tests:
    ```
    /xdmod-qa-new/scripts/install.sh
    /xdmod-qa-new/scripts/build.sh --remote origin/xdmod11.0
    ```
1. Confirm this fails the syntax tests:
    ```
    echo "foo" > bar.json
    git add bar.json
    /xdmod-qa-new/scripts/build.sh --remote origin/xdmod11.0
    ```
1. Confirm this passes the syntax tests:
    ```
    echo "{}" > bar.json
    /xdmod-qa-new/scripts/build.sh --remote origin/xdmod11.0
    ```

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
