### PR TITLE
Fix unit tests path.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -398,10 +398,6 @@ unit_exit_value=0
 php_unit_test_path="tests/unit/runtests.sh"
 php_unit_test_args=""
 
-if [ "$repo_type" != "core" ]; then
-    php_unit_test_path="tests/unit_tests/runtests.sh"
-fi
-
 if [ -n "$SHIPPABLE_BUILD_DIR" ]; then
   php_unit_test_path="$SHIPPABLE_BUILD_DIR/tests/unit/runtests.sh"
   php_unit_test_args="--junit-output-dir $SHIPPABLE_BUILD_DIR/shippable/testresults"


### PR DESCRIPTION
With https://github.com/ubccr/xdmod-supremm/pull/355 and https://github.com/ubccr/xdmod-appkernels/pull/98, the unit tests directory is consistently named `unit` not `unit_tests`.