### PR TITLE
Update Python executable name.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -375,7 +375,7 @@ if array_contains json_files_changed 'composer.json'; then
     # determine whether or not `composer.json` has been changed. If the script
     # exits w/ a 0 then there has been no change. If it exits with anything
     # else then we need to make sure that `composer.lock` has been updated.
-    python "$script_dir/composer_check.py"
+    python3 "$script_dir/composer_check.py"
 
     if [ $? != 0 ]; then
         if ! array_contains other_files_changed 'composer.lock'; then


### PR DESCRIPTION
Currently, if a PR contains an update to `composer.json` (such as https://github.com/ubccr/xdmod-supremm/pull/372), the `build.sh` script will run `python` to check what has changed. However, the Docker images used by CircleCI do not have an executable named `python`. This PR updates the executable name in `build.sh` to `python3`, which the Docker images do have.