### PR TITLE
Allow new `composer.lock` files to be added.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -167,6 +167,7 @@ done
 php_files_added=()
 js_files_added=()
 json_files_added=()
+other_files_added=()
 while IFS= read -r -d $'\0' file; do
     if file $file | grep -q "text" ; then
         last_char=$(tail -c 1 "$file")
@@ -185,6 +186,8 @@ while IFS= read -r -d $'\0' file; do
         js_files_added+=("$file")
     elif [[ "$file" == *.json ]]; then
         json_files_added+=("$file")
+    else
+        other_files_added+=("$file")
     fi
 done < <(git -c diff.renameLimit=6000 diff --name-only --diff-filter=AR -z "$TRAVIS_COMMIT_RANGE")
 
@@ -378,7 +381,8 @@ if array_contains json_files_changed 'composer.json'; then
     python3 "$script_dir/composer_check.py"
 
     if [ $? != 0 ]; then
-        if ! array_contains other_files_changed 'composer.lock'; then
+        if ! array_contains other_files_changed 'composer.lock' && \
+           ! array_contains other_files_added 'composer.lock'; then
             echo "composer.json file changed, but no corresponding change to the lock file"
             extra_exit_value=2
         fi


### PR DESCRIPTION
Currently, if a PR changes `composer.json` while adding a `composer.lock` where there wasn't one before (such as in https://github.com/ubccr/xdmod-supremm/pull/372), then the extra tests in `build.sh` fail because they do not recognize `composer.lock` as having changed, because they are only checking the files that changed, not the files that were added. This PR creates a new array of `other_files_added` and makes sure the extra tests also check it when checking if `composer.lock` was updated.