### PR TITLE
Updated Style Change to handle _coverage_dumper 

### DIFF
--- a/style/configs/phpcs.xml
+++ b/style/configs/phpcs.xml
@@ -29,7 +29,7 @@
   </rule>
   <rule ref="VariableAnalysis">
     <properties>
-      <property name="validUnusedVariableNames" value="unused" />
+      <property name="validUnusedVariableNames" value="unused _coverage_dumper" />
       <property name="allowUnusedFunctionParameters" value="true" />
     </properties>
   </rule>


### PR DESCRIPTION
_coverage_dumper is needed for Xdebug to give coverage when ran this needed to be updated in our qa to allow that variable to used and flag it as valid. 