### PR TITLE
Exclude raw data regression test artifacts from trailing whitespace checks.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -365,7 +365,7 @@ for file in "${php_files_changed[@]}" "${js_files_changed[@]}" "${json_files_cha
     fi
 done
 
-if ! git diff --check $TRAVIS_COMMIT_RANGE ':(exclude)*.sql' ':(exclude)*.patch';
+if ! git diff --check $TRAVIS_COMMIT_RANGE ':(exclude)*.sql' ':(exclude)*.patch' ':(exclude)tests/artifacts/xdmod/regression/current/expected/reference/raw-data/**' ':(exclude)tests/artifacts/regression/current/expected/reference/raw-data/**';
 then
     echo "git diff --check failed"
     extra_exit_value=2


### PR DESCRIPTION
This PR excludes the raw data regression test artifacts from trailing whitespace checks to support https://github.com/ubccr/xdmod/pull/2058 since the `/rest/warehouse/raw-data` endpoint is now expected to produce responses of the form:
```
<hex size of row>\r\n<row>\r\n
<hex size of row>\r\n<row>\r\n
...
0\r\n\r\n
```